### PR TITLE
Fix use of PAYMENT_URL for stock and orders

### DIFF
--- a/stress-test/init_orders.py
+++ b/stress-test/init_orders.py
@@ -34,13 +34,13 @@ async def populate_databases():
             await resp.json()
         logger.info("Users created")
         logger.info("Batch creating items ...")
-        url: str = (f"{PAYMENT_URL}/stock/batch_init/"
+        url: str = (f"{STOCK_URL}/stock/batch_init/"
                     f"{NUMBER_0F_ITEMS}/{ITEM_STARTING_STOCK}/{ITEM_PRICE}")
         async with session.post(url) as resp:
             await resp.json()
         logger.info("Items created")
         logger.info("Batch creating orders ...")
-        url: str = (f"{PAYMENT_URL}/orders/batch_init/"
+        url: str = (f"{ORDER_URL}/orders/batch_init/"
                     f"{NUMBER_OF_ORDERS}/{NUMBER_0F_ITEMS}/{NUMBER_OF_USERS}/{ITEM_PRICE}")
         async with session.post(url) as resp:
             await resp.json()


### PR DESCRIPTION
Dear Kyriakos Psarakis,

Currently, the stress-test also uses the PAYMENT_URL for batch init requests of the order and stock service. This means that even if you change the urls.json, it will not work. I've updated both so that it now works after only editing the urls.json. Hopefully this change is appreciated.

Kind regards,
Tip